### PR TITLE
JOML-conversion compatibility fix for Terasology PR #3919.

### DIFF
--- a/src/main/java/org/terasology/computer/display/system/client/DisplayClientSystem.java
+++ b/src/main/java/org/terasology/computer/display/system/client/DisplayClientSystem.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.computer.display.system.client;
 
-import org.terasology.utilities.Assets;
 import org.terasology.computer.display.component.DisplayComponent;
 import org.terasology.computer.display.component.DisplayRenderComponent;
 import org.terasology.entitySystem.entity.EntityBuilder;
@@ -29,6 +28,7 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
@@ -38,6 +38,7 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.mesh.MeshBuilder;
 import org.terasology.rendering.logic.MeshComponent;
 import org.terasology.rendering.nui.Color;
+import org.terasology.utilities.Assets;
 import org.terasology.world.block.BlockPart;
 import org.terasology.world.block.shapes.BlockMeshPart;
 import org.terasology.world.block.shapes.BlockShape;
@@ -216,19 +217,19 @@ public class DisplayClientSystem extends BaseComponentSystem implements DisplayR
     }
 
     private Vector3f getBottomLeft(Vector3i monitorSize, BlockMeshPart meshPart) {
-        return applySizeToSideVector(monitorSize, meshPart.getVertex(1));
+        return applySizeToSideVector(monitorSize, JomlUtil.from(meshPart.getVertex(1)));
     }
 
     private Vector3f getBottomRight(Vector3i monitorSize, BlockMeshPart meshPart) {
-        return applySizeToSideVector(monitorSize, meshPart.getVertex(2));
+        return applySizeToSideVector(monitorSize, JomlUtil.from(meshPart.getVertex(2)));
     }
 
     private Vector3f getTopRight(Vector3i monitorSize, BlockMeshPart meshPart) {
-        return applySizeToSideVector(monitorSize, meshPart.getVertex(3));
+        return applySizeToSideVector(monitorSize, JomlUtil.from(meshPart.getVertex(3)));
     }
 
     private Vector3f getTopLeft(Vector3i monitorSize, BlockMeshPart meshPart) {
-        return applySizeToSideVector(monitorSize, meshPart.getVertex(0));
+        return applySizeToSideVector(monitorSize, JomlUtil.from(meshPart.getVertex(0)));
     }
 
     private Vector3f applySizeToSideVector(Vector3i monitorSize, Vector3f v2) {


### PR DESCRIPTION
This PR fixes the module's engine compatibility with the JOML-conversion related changes, done in PR  #[3919](https://github.com/MovingBlocks/Terasology/pull/3919).

It should be merged after #3919 has been successfully merged.