### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/computer/display/component/DisplayComponent.java
+++ b/src/main/java/org/terasology/computer/display/component/DisplayComponent.java
@@ -13,10 +13,10 @@ import java.util.List;
 
 @Replicate
 public class DisplayComponent implements Component<DisplayComponent> {
-    private Vector3i monitorSize = new Vector3i();
-    private Side front;
-    private String mode;
-    private List<String> data = Lists.newArrayList();
+    public Vector3i monitorSize = new Vector3i();
+    public Side front;
+    public String mode;
+    public List<String> data = Lists.newArrayList();
 
     public DisplayComponent() {
     }

--- a/src/main/java/org/terasology/computer/display/component/DisplayDataHolderComponent.java
+++ b/src/main/java/org/terasology/computer/display/component/DisplayDataHolderComponent.java
@@ -11,10 +11,10 @@ import org.terasology.gestalt.entitysystem.component.Component;
 import java.util.List;
 
 public class DisplayDataHolderComponent implements Component<DisplayDataHolderComponent> {
-    private Vector3i monitorSize = new Vector3i();
-    private Side front;
-    private String mode;
-    private List<String> data = Lists.newArrayList();
+    public Vector3i monitorSize = new Vector3i();
+    public Side front;
+    public String mode;
+    public List<String> data = Lists.newArrayList();
 
     public DisplayDataHolderComponent() {
     }


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191